### PR TITLE
Fix problem with adding admin role to user

### DIFF
--- a/ProjectComite/ProjectComite.csproj
+++ b/ProjectComite/ProjectComite.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.10" />
   </ItemGroup>

--- a/ProjectComite/appsettings.json
+++ b/ProjectComite/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "ComiteConnection": "server=edudb.thomasmore.be,3000;Database=Data_r0809589;user id=sql_r0809589;password=sql4you",
+    "ComiteConnection": "server=edudb.thomasmore.be,3000;Database=Data_r0809589;user id=sql_r0809589;password=sql4you"
     //"LocalConnection": "server=DESKTOP-H0S2DG6;Database=Comite;Trusted_Connection=True;"
   },
   "Logging": {


### PR DESCRIPTION
Dag Wouter

In een aparte branch (add-admin-role) heb ik enkele zaken aangepast zodat de admin rol correct wordt aangemaakt.
Ik heb deze aanpassingen niet rechtstreeks in jouw master branch gemaakt omdat ik jouw code niet zonder jouw toelating wou aanpassen. Daarom heb ik deze pull request aangemaakt zodat je de wijzigingen eerst nog kan bekijken en eventueel nog kan aanpassen.

Hieronder vind je een overzicht van de zaken die ik heb aangepast:
- Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore toegevoegd via NuGet
- .AddRoles<IdentityRole>() toevoegd aan de ConfigureServices zodat deze correct worden geladen via Dependency Injection
- Er ontbrak nog een '}' in jouw code, want de code van de helper functie CreateUserRoles stond nu nog rechtstreeks in de Configure methode.
- De 'belangrijkste' aanpassing die ik heb gemaakt is het ophalen van de admin user. In de originele code wordt de methode Context.Users.FirstOrDefaultAsync() gebruikt. Met deze methode ga je de gebruiker asynchroon ophalen. Als je een asynchrone methode gebruikt moet je altijd het keyword 'await' toevoegen, want anders krijg je een 'Task' terug ipv een user/data object. Een andere oplossing is om de gebruiker synchroon op te halen met Context.Users.FirstOrDefault(). Dit is de code die ik heb gebruikt.

Vriendelijke groeten
Danny Wouters